### PR TITLE
Extract PS1 to mock user prompt

### DIFF
--- a/Sources/REPL/main.swift
+++ b/Sources/REPL/main.swift
@@ -39,7 +39,7 @@ let c_args = args.map { $0.withCString(strdup)! }
 defer { for arg in c_args { free(arg) } }
 
 var pid = pid_t()
-let rv = posix_spawnp(&pid, c_args[0], &action, nil, c_args + [nil], environ)
+let rv = posix_spawn(&pid, c_args[0], &action, nil, c_args + [nil], environ)
 guard rv == 0 else {
   // Should get errno
   exit(1)

--- a/Sources/REPL/main.swift
+++ b/Sources/REPL/main.swift
@@ -42,7 +42,7 @@ let convertedPS1 = rawPS1.replacingOccurrences(of: #"\033"#, with: "\u{001B}").r
                         .replacingOccurrences(of: #"\h"#, with: ProcessInfo.processInfo.hostName)
                         .replacingOccurrences(of: #"\H"#, with: ProcessInfo.processInfo.hostName)
                         .replacingOccurrences(of: #"\j"#, with: "0") //jobs — since we won't allow backgrounding, always 0
-                        .replacingOccurrences(of: #"\l"#, with: "[repl]") //"The basename of the shell's terminal device name." We don't have one
+                        .replacingOccurrences(of: #"\l"#, with: String(cString: ttyname(STDIN_FILENO)).split(separator: "/").last!) //"The basename of the shell's terminal device name."
                         .replacingOccurrences(of: #"\s"#, with: CommandLine.arguments[0].split(separator: "/").last!) //"The name of the shell, the basename of $0 (the portion following the final slash)."
                         //.replOcc("t", "T", "@") //time, must be done every time we print prompt
                         //\t   The time, in 24-hour HH:MM:SS format. 

--- a/Sources/REPL/main.swift
+++ b/Sources/REPL/main.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+let MAJOR_VERSION = 1
+let MINOR_VERSION = 1
+let PATCH_VERSION = 0
+
 // MARK: - Extract PS1
 //   (via `bash -i -c 'echo "$PS1"'`)
 var action: posix_spawn_file_actions_t? = nil
@@ -45,8 +49,8 @@ let convertedPS1 = rawPS1.replacingOccurrences(of: #"\033"#, with: "\u{001B}").r
                         //\T   The time, in 12-hour HH:MM:SS format. 
                         //\@   The time, in 12-hour am/pm format.
                         .replacingOccurrences(of: #"\u"#, with: ProcessInfo.processInfo.userName)
-                        .replacingOccurrences(of: #"\v"#, with: "1.0") //version major.minor, no patch
-                        .replacingOccurrences(of: #"\V"#, with: "1.0.0") //version major.minor.patch
+                        .replacingOccurrences(of: #"\v"#, with: "\(MAJOR_VERSION).\(MINOR_VERSION)") //version major.minor, no patch
+                        .replacingOccurrences(of: #"\V"#, with: "\(MAJOR_VERSION).\(MINOR_VERSION).\(PATCH_VERSION)") //version major.minor.patch
                         //.replacingOccurrences(of: #"\!"#, with: "1.0") //history number
                         //.replacingOccurrences(of: #"\#"#, with: "1.0") //command number (i.e. length of commands list)
                         .replacingOccurrences(of: #"\$"#, with: getuid() == 0 ? "#" : "$") //'#' iff root else '$'

--- a/Sources/REPL/main.swift
+++ b/Sources/REPL/main.swift
@@ -71,7 +71,7 @@ let convertedPS1 = rawPS1.replacingOccurrences(of: #"\033"#, with: "\u{001B}").r
                         //\@   The time, in 12-hour am/pm format.
                         .replacingOccurrences(of: #"\u"#, with: ProcessInfo.processInfo.userName)
                         .replacingOccurrences(of: #"\v"#, with: "1.0") //version major.minor, no patch
-                        .replacingOccurrences(of: #"\v"#, with: "1.0.0") //version major.minor.patch
+                        .replacingOccurrences(of: #"\V"#, with: "1.0.0") //version major.minor.patch
                         //.replacingOccurrences(of: #"\!"#, with: "1.0") //history number
                         //.replacingOccurrences(of: #"\#"#, with: "1.0") //command number (i.e. length of commands list)
                         //.replacingOccurrences(of: #"\$"#, with: "1.0") //'#' iff root else '$'

--- a/Sources/REPL/main.swift
+++ b/Sources/REPL/main.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 let command = CommandLine.arguments.dropFirst().joined(separator: " ")
-let cmdPrompt = "\u{001B}[38;5;9m[\(NSUserName())]\u{001B}[1;34m(\(FileManager.default.currentDirectoryPath.replacingOccurrences(of: "/Users/\(NSUserName())", with: "~")))\u{001B}[m\u{001B}[1;32m$ \(command)\u{001B}[00m "
+//func posix_exec(_ args: [String]) {
+//    var pid: pid_t = 0
+//    let args = ["/usr/bin/env", "bash", "-i", "-c", #"echo "$PS1""#]
+//    let c_args = args.map { $0.withCString(strdup)! }
+//    posix_spawn(&pid, c_args[0], nil, nil, c_args + [nil], environ)
+//    waitpid(pid, nil, 0)
+//}
 
 var task: Process = Process()
 func exec(_ command: String) -> String {
@@ -19,6 +25,60 @@ func exec(_ command: String) -> String {
     return output
 }
 
+// MARK: - Extract PS1
+//   (via `bash -i -c 'echo "$PS1"'`)
+var action: posix_spawn_file_actions_t? = nil
+posix_spawn_file_actions_init(&action);
+defer { posix_spawn_file_actions_destroy(&action) }
+let m: mode_t = S_IRWXU | S_IRWXG | S_IRWXO
+posix_spawn_file_actions_addopen(&action, 1, "/tmp/ps1", (O_WRONLY | O_CREAT | O_TRUNC), m)
+//posix_spawn_file_actions_adddup2(&action, 1, 2)
+
+let args = ["/usr/bin/env", "bash", "-i", "-c", #"echo -n "$PS1""#]
+let c_args = args.map { $0.withCString(strdup)! }
+defer { for arg in c_args { free(arg) } }
+
+var pid = pid_t()
+let rv = posix_spawnp(&pid, c_args[0], &action, nil, c_args + [nil], environ)
+guard rv == 0 else {
+  // Should get errno
+  exit(1)
+}
+print(pid)
+
+var exitCode: Int32 = 0
+waitpid(pid, &exitCode, 0)
+
+//print("Process exited with code \(exitCode)")
+
+let rawPS1 = try! String(contentsOfFile: "/tmp/ps1")
+
+// MARK: Convert to coloring, replacements, etc.
+//let s = String(contentsOfFile: .init(fileURLWithPath: "/tmp/ps1"))
+let convertedPS1 = rawPS1.replacingOccurrences(of: #"\033"#, with: "\u{001B}").replacingOccurrences(of: #"\e"#, with: "\u{001B}") //escape chars
+                        .replacingOccurrences(of: #"\["#, with: "").replacingOccurrences(of: #"\]"#, with: "") //used to tell bash the're format chars and not printed
+                        .replacingOccurrences(of: #"\w"#, with: ProcessInfo.processInfo.environment["PWD"]!.replacingOccurrences(of: "/Users/\(ProcessInfo.processInfo.userName)", with: "~")) //current working directory
+                        .replacingOccurrences(of: #"\W"#, with: ProcessInfo.processInfo.environment["PWD"]!.split(separator: "/").last!) //CWD basename
+                        //.replacingOccurrences(of: #"\d"#, with: "df.dateFormat = "E MMM d"") //should be done every time we print prompt
+                        .replacingOccurrences(of: #"\h"#, with: ProcessInfo.processInfo.hostName)
+                        .replacingOccurrences(of: #"\H"#, with: ProcessInfo.processInfo.hostName)
+                        .replacingOccurrences(of: #"\j"#, with: "0") //jobs — since we won't allow backgrounding, always 0
+                        .replacingOccurrences(of: #"\l"#, with: "[repl]") //"The basename of the shell's terminal device name." We don't have one
+                        .replacingOccurrences(of: #"\s"#, with: CommandLine.arguments[0].split(separator: "/").last!) //"The name of the shell, the basename of $0 (the portion following the final slash)."
+                        //.replOcc("t", "T", "@") //time, must be done every time we print prompt
+                        //\t   The time, in 24-hour HH:MM:SS format. 
+                        //\T   The time, in 12-hour HH:MM:SS format. 
+                        //\@   The time, in 12-hour am/pm format.
+                        .replacingOccurrences(of: #"\u"#, with: ProcessInfo.processInfo.userName)
+                        .replacingOccurrences(of: #"\v"#, with: "1.0") //version major.minor, no patch
+                        .replacingOccurrences(of: #"\v"#, with: "1.0.0") //version major.minor.patch
+                        //.replacingOccurrences(of: #"\!"#, with: "1.0") //history number
+                        //.replacingOccurrences(of: #"\#"#, with: "1.0") //command number (i.e. length of commands list)
+                        //.replacingOccurrences(of: #"\$"#, with: "1.0") //'#' iff root else '$'
+print(convertedPS1)
+let cmdPrompt = convertedPS1 + "\u{001B}[1;32m\(command)\u{001B}[00m "
+
+// MARK: - Begin REPL
 print("Initializing REPL with command: \(command)")
 print("Use ^D to exit")
 print()

--- a/Sources/REPL/main.swift
+++ b/Sources/REPL/main.swift
@@ -49,7 +49,7 @@ let convertedPS1 = rawPS1.replacingOccurrences(of: #"\033"#, with: "\u{001B}").r
                         .replacingOccurrences(of: #"\V"#, with: "1.0.0") //version major.minor.patch
                         //.replacingOccurrences(of: #"\!"#, with: "1.0") //history number
                         //.replacingOccurrences(of: #"\#"#, with: "1.0") //command number (i.e. length of commands list)
-                        //.replacingOccurrences(of: #"\$"#, with: "1.0") //'#' iff root else '$'
+                        .replacingOccurrences(of: #"\$"#, with: getuid() == 0 ? "#" : "$") //'#' iff root else '$'
 
 //MARK: - Build command prompt function
 struct ReplacingDate {

--- a/Sources/REPL/main.swift
+++ b/Sources/REPL/main.swift
@@ -29,7 +29,7 @@ let cct = (c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c) // Set of
 var originalTerm: termios = termios(c_iflag: 0, c_oflag: 0, c_cflag: 0, c_lflag: 0, c_cc: cct, c_ispeed: 0, c_ospeed: 0)
 tcgetattr(STDIN_FILENO, &originalTerm) //this gets the current settings
 var term = originalTerm
-term.c_lflag &= (UInt.max ^ UInt(Darwin.ECHO) ^ UInt(Darwin.ICANON)) //turn off ECHO and ICANON
+term.c_lflag &= ~(UInt(Darwin.ECHO) | UInt(Darwin.ICANON)) //turn off ECHO and ICANON
 tcsetattr(STDIN_FILENO, TCSANOW, &term) //set these new settings
 
 func resetTermAndExitWith(sig: Int32) {


### PR DESCRIPTION
This PR closes #3.

I was able to extract the user's prompt in a privacy-preserving way by executing `bash -i -c 'echo "$PS1"'` and interpreting the result. Most bash-based user prompt should be functional. Here's the list of supported and unsupported-but-in-the-works variables that can be used in a bash prompt:

- [x] `\[` and `\]` (used to tell bash that the enclosing characters are for format only, to calculate word wrapping)
- [x] `\w` (current working directory)
- [x] `\W` (basename of CWD)
- [ ] `\d`(current date)
- [x] `\h` hostname[^1]
- [x] `\H` hostname (full)[^1]
- [x] `\j` (jobs managed by the shell)[^2]
- [x] `\l` (terminal device of shell)[^3]
- [x] `\s` (name of shell)[^4]
- [ ] `\t`, `\T`, `\@` (current time in various formats)
- [x] `\u` (username)
- [x] `\v` (shell version, no patch)[^5]
- [x] `\V` (shell version, with patch)[^5]
- [ ] `\!` (history number)[^6]
- [ ] `\#` (command number)[^7]
- [ ] `\$` (`#` if root, otherwise `$`)[^8]

Note that all but one of the incomplete variables must be recomputed every time we print the prompt (which is why I didn't implement them immediately). They _shouldn't_ be too hard (I already was able to print the date in the correct format, I just need to do it every time instead of once). It'll just take some restructuring.

[^1]: For some reason, on the two computers that I tested it on, bash was giving me the same result, so I suspect one of these is implemented correctly and the other is not. Please let me know!
[^2]: At the moment, we don't allow backgrounding jobs _in REPL_, so this is permanently `0`
[^3]: We don't have a terminal device, so this is `[repl]`
[^4]: We are the shell, so generally `repl`. I did actually implement this correctly (taking the basename of `$0`), which means that if the binary is renamed or symlinked, this will correctly reflect that.
[^5]: This will give the REPL version. Currently hardcoded to `1.0` and `1.0.0`
[^6]: Waiting on a decision for whether REPL will support history (#7)
[^7]: Will only count the commands you've entered into REPL. Should be easy enough, as we maintain them for up and down arrows already.
[^8]: There's no way to switch users in REPL (unless you're doing something funky like `repl su`, but ~~i doubt that would work~~ that does not work anyway). So this will probably read your UID when REPL launches, and set it then (I suppose we could also check if your username is `root`, but I think the formal spec is that it's when your UID is 0).